### PR TITLE
Fix `even`/`odd` check for fractional numbers

### DIFF
--- a/Sources/Jinja/Tests.swift
+++ b/Sources/Jinja/Tests.swift
@@ -137,6 +137,7 @@ public enum Tests {
         case let .int(num):
             return num % 2 == 0
         case let .double(num):
+            guard num.isFinite && num.truncatingRemainder(dividingBy: 1.0) == 0.0 else { return false }
             return Int(num) % 2 == 0
         default:
             return false
@@ -160,6 +161,7 @@ public enum Tests {
         case let .int(num):
             return num % 2 != 0
         case let .double(num):
+            guard num.isFinite && num.truncatingRemainder(dividingBy: 1.0) == 0.0 else { return false }
             return Int(num) % 2 != 0
         default:
             return false

--- a/Sources/Jinja/Tests.swift
+++ b/Sources/Jinja/Tests.swift
@@ -137,8 +137,7 @@ public enum Tests {
         case let .int(num):
             return num % 2 == 0
         case let .double(num):
-            guard num.isFinite && num.truncatingRemainder(dividingBy: 1.0) == 0.0 else { return false }
-            return Int(num) % 2 == 0
+            return num.isFinite && num.truncatingRemainder(dividingBy: 2.0) == 0.0
         default:
             return false
         }
@@ -161,8 +160,8 @@ public enum Tests {
         case let .int(num):
             return num % 2 != 0
         case let .double(num):
-            guard num.isFinite && num.truncatingRemainder(dividingBy: 1.0) == 0.0 else { return false }
-            return Int(num) % 2 != 0
+            return num.isFinite && num.truncatingRemainder(dividingBy: 1.0) == 0.0
+                && num.truncatingRemainder(dividingBy: 2.0) != 0.0
         default:
             return false
         }

--- a/Tests/JinjaTests/TemplateTests.swift
+++ b/Tests/JinjaTests/TemplateTests.swift
@@ -2046,7 +2046,7 @@ struct TemplateTests {
     func isOperatorWithFractionalNumbersEven() throws {
         let string = #"|{{ 4.5 is even }}|{{ 3.7 is even }}|{{ 0.1 is even }}|{{ 2.0 is even }}|"#
         let context: Context = [:]
-        
+
         let rendered = try Template(string).render(context)
         #expect(rendered == "|false|false|false|true|")
     }
@@ -2055,7 +2055,7 @@ struct TemplateTests {
     func isOperatorWithFractionalNumbersOdd() throws {
         let string = #"|{{ 4.5 is odd }}|{{ 3.7 is odd }}|{{ 0.1 is odd }}|{{ 3.0 is odd }}|"#
         let context: Context = [:]
-        
+
         let rendered = try Template(string).render(context)
         #expect(rendered == "|false|false|false|true|")
     }

--- a/Tests/JinjaTests/TemplateTests.swift
+++ b/Tests/JinjaTests/TemplateTests.swift
@@ -2042,6 +2042,24 @@ struct TemplateTests {
         #expect(rendered == "|true|false|true|")
     }
 
+    @Test("Is operator with fractional numbers even")
+    func isOperatorWithFractionalNumbersEven() throws {
+        let string = #"|{{ 4.5 is even }}|{{ 3.7 is even }}|{{ 0.1 is even }}|{{ 2.0 is even }}|"#
+        let context: Context = [:]
+        
+        let rendered = try Template(string).render(context)
+        #expect(rendered == "|false|false|false|true|")
+    }
+
+    @Test("Is operator with fractional numbers odd")
+    func isOperatorWithFractionalNumbersOdd() throws {
+        let string = #"|{{ 4.5 is odd }}|{{ 3.7 is odd }}|{{ 0.1 is odd }}|{{ 3.0 is odd }}|"#
+        let context: Context = [:]
+        
+        let rendered = try Template(string).render(context)
+        #expect(rendered == "|false|false|false|true|")
+    }
+
     @Test("Is operator with mapping")
     func isOperatorWithMapping() throws {
         let string =

--- a/Tests/JinjaTests/TestsTests.swift
+++ b/Tests/JinjaTests/TestsTests.swift
@@ -218,6 +218,18 @@ struct TestsTests {
             try Tests.even([], kwargs: [:], env: env)
         }
     }
+    
+    @Test("even test with fractional numbers")
+    func evenWithFractionalNumbers() throws {
+        let result1 = try Tests.even([.double(4.5)], kwargs: [:], env: env)
+        #expect(result1 == false)
+
+        let result2 = try Tests.even([.double(3.7)], kwargs: [:], env: env)
+        #expect(result2 == false)
+
+        let result3 = try Tests.even([.double(0.1)], kwargs: [:], env: env)
+        #expect(result3 == false)
+    }
 
     @Test("odd test with odd integer")
     func oddWithOddInteger() throws {
@@ -254,6 +266,18 @@ struct TestsTests {
         #expect(throws: JinjaError.self) {
             try Tests.odd([], kwargs: [:], env: env)
         }
+    }
+    
+    @Test("odd test with fractional numbers")
+    func oddWithFractionalNumbers() throws {
+        let result1 = try Tests.odd([.double(4.5)], kwargs: [:], env: env)
+        #expect(result1 == false)
+
+        let result2 = try Tests.odd([.double(3.7)], kwargs: [:], env: env)
+        #expect(result2 == false)
+
+        let result3 = try Tests.odd([.double(0.1)], kwargs: [:], env: env)
+        #expect(result3 == false)
     }
 
     @Test("divisibleby test with divisible integers")
@@ -491,6 +515,10 @@ struct TestsTests {
         )
         #expect(divisibleResult == true)
     }
+
+    
+
+    
 
     // MARK: - New Tests
 

--- a/Tests/JinjaTests/TestsTests.swift
+++ b/Tests/JinjaTests/TestsTests.swift
@@ -218,7 +218,7 @@ struct TestsTests {
             try Tests.even([], kwargs: [:], env: env)
         }
     }
-    
+
     @Test("even test with fractional numbers")
     func evenWithFractionalNumbers() throws {
         let result1 = try Tests.even([.double(4.5)], kwargs: [:], env: env)
@@ -267,7 +267,7 @@ struct TestsTests {
             try Tests.odd([], kwargs: [:], env: env)
         }
     }
-    
+
     @Test("odd test with fractional numbers")
     func oddWithFractionalNumbers() throws {
         let result1 = try Tests.odd([.double(4.5)], kwargs: [:], env: env)
@@ -515,10 +515,6 @@ struct TestsTests {
         )
         #expect(divisibleResult == true)
     }
-
-    
-
-    
 
     // MARK: - New Tests
 


### PR DESCRIPTION
## Swift
<img width="1147" height="704" alt="Xcode 2025-09-26 13 13 48" src="https://github.com/user-attachments/assets/263780c3-20c8-40c3-936f-18365066a314" />
<img width="1153" height="568" alt="Xcode 2025-09-26 13 13 24" src="https://github.com/user-attachments/assets/5fefd593-f183-41df-8c7d-81d4ffa37be0" />

## Python
```python
template = env.from_string("{{ 4.5 is even }}")
result = template.render()
print(f"  4.5 is even: {result}")

template = env.from_string("{{ 4.5 is odd }}")
result = template.render()
print(f"  4.5 is odd: {result}")

template = env.from_string("{{ 3.7 is even }}")
result = template.render()
print(f"  3.7 is even: {result}")

template = env.from_string("{{ 3.7 is odd }}")
result = template.render()
print(f"  3.7 is odd: {result}")

template = env.from_string("{{ 0.1 is even }}")
result = template.render()
print(f"  0.1 is even: {result}")

template = env.from_string("{{ 0.1 is odd }}")
result = template.render()
print(f"  0.1 is odd: {result}")
```

```bash
4.5 is even: False
4.5 is odd: False
3.7 is even: False
3.7 is odd: False
0.1 is even: False
0.1 is odd: False
```