### PR TITLE
Stop escaping slashes in tojson

### DIFF
--- a/Sources/Jinja/Filters.swift
+++ b/Sources/Jinja/Filters.swift
@@ -1057,6 +1057,10 @@ public enum Filters {
 
     /// Converts value to JSON string.
     ///
+    /// Slashes are written as `/`, as `json.dumps` writes them; Foundation's
+    /// default `\/` is a JavaScript-embedding safeguard that a chat template
+    /// does not need and that puts a backslash into the prompt.
+    ///
     /// - Parameters:
     ///   - indent: If greater than 0, enables pretty-printed output using
     ///             Foundation's default indentation (optional).
@@ -1078,6 +1082,7 @@ public enum Filters {
 
         let encoder = JSONEncoder()
         encoder.outputFormatting.insert(.sortedKeys)
+        encoder.outputFormatting.insert(.withoutEscapingSlashes)
         if let indent = arguments["indent"],
             case .int(let count) = indent,
             count > 0

--- a/Sources/Jinja/Filters.swift
+++ b/Sources/Jinja/Filters.swift
@@ -1057,14 +1057,17 @@ public enum Filters {
 
     /// Converts value to JSON string.
     ///
-    /// Slashes are written as `/`, as `json.dumps` writes them; Foundation's
-    /// default `\/` is a JavaScript-embedding safeguard that a chat template
-    /// does not need and that puts a backslash into the prompt.
+    /// Slashes are written as `/`, as `json.dumps` writes them;
+    /// Foundation's default `\/` is a JavaScript-embedding safeguard
+    /// that a chat template does not need
+    /// and that puts a backslash into the prompt.
     ///
     /// - Parameters:
-    ///   - indent: If greater than 0, enables pretty-printed output using
-    ///             Foundation's default indentation (optional).
-    ///   - ensure_ascii: If true (default), escape non-ASCII characters as `\uXXXX`.
+    ///   - indent: If greater than 0,
+    ///             enables pretty-printed output
+    ///             using Foundation's default indentation (optional).
+    ///   - ensure_ascii: If true (default),
+    ///                   escape non-ASCII characters as `\uXXXX`.
     ///                   If false, output Unicode characters directly.
     @Sendable public static func tojson(
         _ args: [Value],

--- a/Tests/JinjaTests/FiltersTests.swift
+++ b/Tests/JinjaTests/FiltersTests.swift
@@ -591,6 +591,19 @@ struct FiltersTests {
         #expect(result == .string("[1,2,3]"))
     }
 
+    @Test("tojson filter does not escape slashes")
+    func tojsonFilterDoesNotEscapeSlashes() throws {
+        let result = try Filters.tojson([.string("</style> a/b")], kwargs: [:], env: env)
+        #expect(result == .string("\"</style> a/b\""))
+    }
+
+    @Test("tojson filter does not escape slashes when pretty printed")
+    func tojsonFilterDoesNotEscapeSlashesWhenPrettyPrinted() throws {
+        let result = try Filters.tojson(
+            [.object(["path": .string("a/b")])], kwargs: ["indent": .int(2)], env: env)
+        #expect(result == .string("{\n  \"path\" : \"a/b\"\n}"))
+    }
+
     @Test("tojson filter sorts object keys deterministically")
     func tojsonFilterSortsObjectKeysDeterministically() throws {
         let tool = Value.object([


### PR DESCRIPTION
Fixes #71.

`tojson` wrote `/` as `\/`, Foundation's default and one of the ways its output differs from the `json.dumps` call behind the `tojson` filter in transformers (the others are listed in the issue). This adds `.withoutEscapingSlashes` to the encoder; two tests in `FiltersTests` cover the compact and the pretty-printed form. The Qwen3-family templates pipe every tool schema and every non-string tool-call argument through `tojson`, so until now the model read a backslash before every slash in its tool descriptions.
