### PR TITLE
Fix swift-format lint findings from #72

### DIFF
--- a/Tests/JinjaTests/FiltersTests.swift
+++ b/Tests/JinjaTests/FiltersTests.swift
@@ -600,7 +600,10 @@ struct FiltersTests {
     @Test("tojson filter does not escape slashes when pretty printed")
     func tojsonFilterDoesNotEscapeSlashesWhenPrettyPrinted() throws {
         let result = try Filters.tojson(
-            [.object(["path": .string("a/b")])], kwargs: ["indent": .int(2)], env: env)
+            [.object(["path": .string("a/b")])],
+            kwargs: ["indent": .int(2)],
+            env: env
+        )
         #expect(result == .string("{\n  \"path\" : \"a/b\"\n}"))
     }
 


### PR DESCRIPTION
The tojson pretty-print test added in #72 broke swift-format lint on main (AddLines rule, missing line breaks). This PR only reformats that test with swift-format; no behavior changes.