### PR TITLE
Serialize tojson like json.dumps and add json.dumps policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,25 +358,44 @@ try template.render(["tool": tool])
 // {"name": "read", "description": "Use offset/limit — see docs"}
 ```
 
-You can change this through the environment's `policies`,
-which mirror Jinja2's
-[`json.dumps_function` and `json.dumps_kwargs`](https://jinja.palletsprojects.com/en/stable/api/#policies).
-To get Jinja2's own `tojson` output,
-which sorts keys, escapes non-ASCII characters,
-and writes `<`, `>`, `&`, and `'` as `\u` escapes
-so the result is safe to embed in HTML:
+The environment's typed `policies` expose the behavior of Jinja2's
+[`json.dumps_function` and `json.dumps_kwargs`](https://jinja.palletsprojects.com/en/stable/api/#policies)
+through `JSON.Serializer` and `JSON.DumpsOptions`.
+Use the `.jinja2` preset for sorted keys, escaped non-ASCII characters,
+and HTML-safe escaping of `<`, `>`, `&`, and `'`:
 
 ```swift
 let environment = Environment()
-environment.policies["json.dumps_function"] = JSON.htmlSafeDumpsFunction
-environment.policies["json.dumps_kwargs"] = ["sort_keys": true]
+environment.policies = .jinja2
 try template.render(["tool": tool], environment: environment)
 ```
 
-Any `json.dumps` keyword argument can go in `json.dumps_kwargs`:
-`ensure_ascii`, `sort_keys`, `indent`, and `separators`.
-An `indent` or `ensure_ascii` argument passed to the filter itself
-takes precedence.
+The default preset is `.transformers`.
+You can customize either preset with typed options:
+
+```swift
+environment.policies = .transformers
+environment.policies.jsonDumpsOptions.sortKeys = true
+environment.policies.jsonDumpsOptions.indent = 2
+environment.policies.jsonDumpsOptions.separators = (item: ",", key: ": ")
+environment.policies.jsonSerializer = .htmlSafe
+```
+
+`JSON.Serializer` supports `.standard`, `.htmlSafe`,
+and `.custom` with a `@Sendable (Value, JSON.DumpsOptions) throws -> String` closure.
+Custom serializers receive the resolved options, including template overrides:
+
+```swift
+environment.policies.jsonSerializer = .custom { value, options in
+    try JSON.dumps(value, options: options)
+}
+```
+
+The `tojson` filter's non-null `indent` and `ensure_ascii` arguments
+override the policy options for that call without changing the environment.
+An indentation of zero or less inserts newlines without leading spaces.
+Policies are inherited from the parent environment until a child changes a policy,
+which copies all inherited settings into that child.
 The serializer is also available directly as `JSON.dumps(_:options:)`.
 
 ### Tests

--- a/README.md
+++ b/README.md
@@ -342,6 +342,43 @@ let context: [String: Value] = [
 let result = try template.render(context)
 ```
 
+#### JSON output
+
+The `tojson` filter writes JSON the way Python's `json.dumps` does,
+so a chat template renders the same text here as it does in
+[transformers](https://github.com/huggingface/transformers).
+Like transformers, the defaults are `ensure_ascii=False` and `sort_keys=False`:
+non-ASCII characters are kept as they are,
+and object keys stay in insertion order.
+
+```swift
+let template = try Template("{{ tool | tojson }}")
+let tool: Value = ["name": "read", "description": "Use offset/limit — see docs"]
+try template.render(["tool": tool])
+// {"name": "read", "description": "Use offset/limit — see docs"}
+```
+
+You can change this through the environment's `policies`,
+which mirror Jinja2's
+[`json.dumps_function` and `json.dumps_kwargs`](https://jinja.palletsprojects.com/en/stable/api/#policies).
+To get Jinja2's own `tojson` output,
+which sorts keys, escapes non-ASCII characters,
+and writes `<`, `>`, `&`, and `'` as `\u` escapes
+so the result is safe to embed in HTML:
+
+```swift
+let environment = Environment()
+environment.policies["json.dumps_function"] = JSON.htmlSafeDumpsFunction
+environment.policies["json.dumps_kwargs"] = ["sort_keys": true]
+try template.render(["tool": tool], environment: environment)
+```
+
+Any `json.dumps` keyword argument can go in `json.dumps_kwargs`:
+`ensure_ascii`, `sort_keys`, `indent`, and `separators`.
+An `indent` or `ensure_ascii` argument passed to the filter itself
+takes precedence.
+The serializer is also available directly as `JSON.dumps(_:options:)`.
+
 ### Tests
 
 Jinja provides

--- a/Sources/Jinja/Filters.swift
+++ b/Sources/Jinja/Filters.swift
@@ -1055,20 +1055,18 @@ public enum Filters {
         return try forceescape(args, kwargs: kwargs, env: env)
     }
 
-    /// Converts value to JSON string.
+    /// Converts value to a JSON string.
     ///
-    /// Slashes are written as `/`, as `json.dumps` writes them;
-    /// Foundation's default `\/` is a JavaScript-embedding safeguard
-    /// that a chat template does not need
-    /// and that puts a backslash into the prompt.
+    /// The output follows the environment's `json.dumps_function`
+    /// and `json.dumps_kwargs` policies (see ``Environment/policies``).
+    /// By default that is Python's `json.dumps` with `ensure_ascii=False`,
+    /// which is what transformers uses to render chat templates.
     ///
     /// - Parameters:
-    ///   - indent: If greater than 0,
-    ///             enables pretty-printed output
-    ///             using Foundation's default indentation (optional).
-    ///   - ensure_ascii: If true (default),
-    ///                   escape non-ASCII characters as `\uXXXX`.
-    ///                   If false, output Unicode characters directly.
+    ///   - indent: Number of spaces to indent nested values by.
+    ///             Overrides the `indent` in `json.dumps_kwargs`.
+    ///   - ensure_ascii: Whether to escape non-ASCII characters as `\uXXXX`.
+    ///                   Overrides the `ensure_ascii` in `json.dumps_kwargs`.
     @Sendable public static func tojson(
         _ args: [Value],
         kwargs: [String: Value] = [:],
@@ -1080,36 +1078,30 @@ public enum Filters {
             args: Array(args.dropFirst()),
             kwargs: kwargs,
             parameters: ["indent", "ensure_ascii"],
-            defaults: ["indent": .null, "ensure_ascii": .boolean(true)]
+            defaults: ["indent": .null, "ensure_ascii": .null]
         )
 
-        let encoder = JSONEncoder()
-        encoder.outputFormatting.insert(.sortedKeys)
-        encoder.outputFormatting.insert(.withoutEscapingSlashes)
-        if let indent = arguments["indent"],
-            case .int(let count) = indent,
-            count > 0
-        {
-            encoder.outputFormatting.insert(.prettyPrinted)
-        }
-
-        let ensureASCII: Bool
-        if let ensureASCIIValue = arguments["ensure_ascii"] {
-            ensureASCII = ensureASCIIValue.isTruthy
-        } else {
-            ensureASCII = true
-        }
-
-        if let jsonData = (try? encoder.encode(value)),
-            let jsonString = String(data: jsonData, encoding: .utf8)
-        {
-            if ensureASCII {
-                return .string(escapeNonASCII(jsonString))
+        var dumpsKwargs: [String: Value] = [:]
+        if case let .object(policy) = env.policies["json.dumps_kwargs"] {
+            for (key, value) in policy {
+                dumpsKwargs[key.stringValue] = value
             }
-            return .string(jsonString)
-        } else {
-            return .string("null")
         }
+        for name in ["indent", "ensure_ascii"] {
+            if let argument = arguments[name], argument != .null {
+                dumpsKwargs[name] = argument
+            }
+        }
+
+        if case let .function(dumps) = env.policies["json.dumps_function"] {
+            let result = try dumps([value], dumpsKwargs, env)
+            guard case .string = result else {
+                throw JinjaError.runtime("json.dumps_function must return a string")
+            }
+            return result
+        }
+
+        return .string(try JSON.dumps(value, options: try JSON.DumpsOptions(kwargs: dumpsKwargs)))
     }
 
     /// Returns absolute value of a number.
@@ -2089,19 +2081,6 @@ private func htmlEscape(_ string: String) -> String {
 ///
 /// - Parameter string: The string to escape.
 /// - Returns: An ASCII-only string with non-ASCII characters escaped.
-private func escapeNonASCII(_ string: String) -> String {
-    var result = ""
-    result.reserveCapacity(string.utf16.count)
-    for codeUnit in string.utf16 {
-        if codeUnit > 127 {
-            result += String(format: "\\u%04x", codeUnit)
-        } else if let scalar = UnicodeScalar(codeUnit) {
-            result.append(Character(scalar))
-        }
-    }
-    return result
-}
-
 /// Returns the value of an attribute on an item.
 ///
 /// Resolves string attribute names through property members,

--- a/Sources/Jinja/Filters.swift
+++ b/Sources/Jinja/Filters.swift
@@ -1057,16 +1057,16 @@ public enum Filters {
 
     /// Converts value to a JSON string.
     ///
-    /// The output follows the environment's `json.dumps_function`
-    /// and `json.dumps_kwargs` policies (see ``Environment/policies``).
+    /// The output follows the environment's typed JSON policies
+    /// (see ``Environment/policies``).
     /// By default that is Python's `json.dumps` with `ensure_ascii=False`,
     /// which is what transformers uses to render chat templates.
     ///
     /// - Parameters:
     ///   - indent: Number of spaces to indent nested values by.
-    ///             Overrides the `indent` in `json.dumps_kwargs`.
+    ///             Overrides the policy's indentation.
     ///   - ensure_ascii: Whether to escape non-ASCII characters as `\uXXXX`.
-    ///                   Overrides the `ensure_ascii` in `json.dumps_kwargs`.
+    ///                   Overrides the policy's non-ASCII escaping.
     @Sendable public static func tojson(
         _ args: [Value],
         kwargs: [String: Value] = [:],
@@ -1081,27 +1081,21 @@ public enum Filters {
             defaults: ["indent": .null, "ensure_ascii": .null]
         )
 
-        var dumpsKwargs: [String: Value] = [:]
-        if case let .object(policy) = env.policies["json.dumps_kwargs"] {
-            for (key, value) in policy {
-                dumpsKwargs[key.stringValue] = value
-            }
+        let policies = env.policies
+        var options = policies.jsonDumpsOptions
+        switch arguments["indent"] {
+        case .int(let count):
+            options.indent = count
+        case .null, .undefined, nil:
+            break
+        default:
+            throw JinjaError.runtime("tojson indent must be an integer or none")
         }
-        for name in ["indent", "ensure_ascii"] {
-            if let argument = arguments[name], argument != .null {
-                dumpsKwargs[name] = argument
-            }
-        }
-
-        if case let .function(dumps) = env.policies["json.dumps_function"] {
-            let result = try dumps([value], dumpsKwargs, env)
-            guard case .string = result else {
-                throw JinjaError.runtime("json.dumps_function must return a string")
-            }
-            return result
+        if let ensureASCII = arguments["ensure_ascii"], ensureASCII != .null {
+            options.ensureASCII = ensureASCII.isTruthy
         }
 
-        return .string(try JSON.dumps(value, options: try JSON.DumpsOptions(kwargs: dumpsKwargs)))
+        return .string(try policies.jsonSerializer.dumps(value, options: options))
     }
 
     /// Returns absolute value of a number.

--- a/Sources/Jinja/Interpreter.swift
+++ b/Sources/Jinja/Interpreter.swift
@@ -27,41 +27,49 @@ public final class Environment: @unchecked Sendable {
     /// The default value is `false`.
     public var trimBlocks: Bool = false
 
-    /// Settings that adjust how built-in filters behave,
-    /// mirroring Jinja2's `Environment.policies`.
+    /// Settings that adjust the behavior of built-in filters.
+    public struct Policies: Sendable {
+        /// The serializer corresponding to Jinja2's `json.dumps_function` policy.
+        public var jsonSerializer: JSON.Serializer
+
+        /// Options corresponding to Jinja2's `json.dumps_kwargs` policy.
+        /// Explicit non-null `tojson` arguments override these options for that call.
+        public var jsonDumpsOptions: JSON.DumpsOptions
+
+        /// Creates policies with Transformers-compatible defaults.
+        public init(
+            jsonSerializer: JSON.Serializer = .standard,
+            jsonDumpsOptions: JSON.DumpsOptions = .init(ensureASCII: false)
+        ) {
+            self.jsonSerializer = jsonSerializer
+            self.jsonDumpsOptions = jsonDumpsOptions
+        }
+
+        /// Plain JSON with non-ASCII characters and insertion order preserved.
+        public static let transformers = Policies()
+
+        /// HTML-safe JSON with sorted keys and non-ASCII characters escaped.
+        public static let jinja2 = Policies(
+            jsonSerializer: .htmlSafe,
+            jsonDumpsOptions: .init(ensureASCII: true, sortKeys: true)
+        )
+    }
+
+    /// Settings that adjust how built-in filters behave.
     ///
-    /// Policies are inherited from the parent environment
-    /// until an environment sets its own.
-    /// The recognized keys are:
-    ///
-    /// - `json.dumps_function`:
-    ///   The function `tojson` calls as `function(value, **kwargs)`.
-    ///   `.null` selects ``JSON/dumps(_:options:)``.
-    ///   ``JSON/htmlSafeDumpsFunction`` gives Jinja2's HTML-safe output.
-    /// - `json.dumps_kwargs`:
-    ///   Keyword arguments for that function,
-    ///   using the names of Python's `json.dumps` parameters.
-    ///   The `indent` argument passed to `tojson` overrides the one set here.
-    ///
-    /// The defaults match what transformers uses to render chat templates:
-    /// `ensure_ascii` false and `sort_keys` false.
-    /// To get Jinja2's own `tojson` output instead:
-    ///
-    /// ```swift
-    /// environment.policies["json.dumps_function"] = JSON.htmlSafeDumpsFunction
-    /// environment.policies["json.dumps_kwargs"] = ["sort_keys": true]
-    /// ```
-    public var policies: [String: Value] {
+    /// Policies are inherited from the parent environment until any policy is set.
+    /// Mutating a policy copies all inherited settings into this environment;
+    /// subsequent parent changes do not affect that copy.
+    /// Root environments default to ``Policies/transformers``.
+    /// Set `environment.policies = .jinja2` for sorted, ASCII, HTML-safe JSON.
+    public var policies: Policies {
         get { policyStorage ?? parent?.policies ?? Environment.defaultPolicies }
         set { policyStorage = newValue }
     }
-    private var policyStorage: [String: Value]?
+    private var policyStorage: Policies?
 
     /// The policies a root environment starts with.
-    public static let defaultPolicies: [String: Value] = [
-        "json.dumps_function": .null,
-        "json.dumps_kwargs": ["ensure_ascii": false, "sort_keys": false],
-    ]
+    public static let defaultPolicies: Policies = .transformers
 
     // MARK: -
 
@@ -154,6 +162,7 @@ public enum Interpreter {
     public static func interpret(_ nodes: [Node], environment: Environment) throws -> String {
         // Use the fast path with synchronous environment
         let env = Environment(initial: environment.variables)
+        env.policies = environment.policies
         var buffer = ""
         buffer.reserveCapacity(1024)
         try interpret(nodes, env: env, into: &buffer)

--- a/Sources/Jinja/Interpreter.swift
+++ b/Sources/Jinja/Interpreter.swift
@@ -27,6 +27,42 @@ public final class Environment: @unchecked Sendable {
     /// The default value is `false`.
     public var trimBlocks: Bool = false
 
+    /// Settings that adjust how built-in filters behave,
+    /// mirroring Jinja2's `Environment.policies`.
+    ///
+    /// Policies are inherited from the parent environment
+    /// until an environment sets its own.
+    /// The recognized keys are:
+    ///
+    /// - `json.dumps_function`:
+    ///   The function `tojson` calls as `function(value, **kwargs)`.
+    ///   `.null` selects ``JSON/dumps(_:options:)``.
+    ///   ``JSON/htmlSafeDumpsFunction`` gives Jinja2's HTML-safe output.
+    /// - `json.dumps_kwargs`:
+    ///   Keyword arguments for that function,
+    ///   using the names of Python's `json.dumps` parameters.
+    ///   The `indent` argument passed to `tojson` overrides the one set here.
+    ///
+    /// The defaults match what transformers uses to render chat templates:
+    /// `ensure_ascii` false and `sort_keys` false.
+    /// To get Jinja2's own `tojson` output instead:
+    ///
+    /// ```swift
+    /// environment.policies["json.dumps_function"] = JSON.htmlSafeDumpsFunction
+    /// environment.policies["json.dumps_kwargs"] = ["sort_keys": true]
+    /// ```
+    public var policies: [String: Value] {
+        get { policyStorage ?? parent?.policies ?? Environment.defaultPolicies }
+        set { policyStorage = newValue }
+    }
+    private var policyStorage: [String: Value]?
+
+    /// The policies a root environment starts with.
+    public static let defaultPolicies: [String: Value] = [
+        "json.dumps_function": .null,
+        "json.dumps_kwargs": ["ensure_ascii": false, "sort_keys": false],
+    ]
+
     // MARK: -
 
     /// Creates a new environment with optional parent and initial variables.

--- a/Sources/Jinja/JSON.swift
+++ b/Sources/Jinja/JSON.swift
@@ -64,7 +64,7 @@ public enum JSON {
     /// Serializes a value the way `json.dumps` does.
     ///
     /// - Throws: `JinjaError.runtime` when the value contains something
-    ///   that has no JSON representation, such as a function.
+    ///   that has no JSON representation, such as an undefined value or a function.
     public static func dumps(_ value: Value, options: DumpsOptions = DumpsOptions()) throws -> String {
         var writer = Writer(options: options)
         try writer.write(value, depth: 0)
@@ -107,8 +107,10 @@ extension JSON {
 
         mutating func write(_ value: Value, depth: Int) throws {
             switch value {
-            case .null, .undefined:
+            case .null:
                 output += "null"
+            case .undefined:
+                throw JinjaError.runtime("Object of type Undefined is not JSON serializable")
             case let .boolean(flag):
                 output += flag ? "true" : "false"
             case let .int(number):

--- a/Sources/Jinja/JSON.swift
+++ b/Sources/Jinja/JSON.swift
@@ -1,0 +1,274 @@
+import Foundation
+
+/// JSON serialization with the semantics of Python's `json.dumps`.
+///
+/// Jinja2's `tojson` filter and the `json.dumps` call that transformers
+/// substitutes for it both produce this format,
+/// so templates written against either render the same text here.
+public enum JSON {
+    /// Keyword arguments for ``dumps(_:options:)``,
+    /// named after the `json.dumps` parameters they correspond to.
+    public struct DumpsOptions: Sendable {
+        /// Escape every non-ASCII character as `\uXXXX`.
+        /// The default is `true`, as in `json.dumps`.
+        public var ensureASCII: Bool
+
+        /// Write object keys in sorted order instead of insertion order.
+        public var sortKeys: Bool
+
+        /// Number of spaces to indent nested values by.
+        /// `nil` writes everything on one line.
+        public var indent: Int?
+
+        /// The separators written between items and between a key and its value.
+        /// `nil` selects `json.dumps`' defaults:
+        /// `", "` and `": "`, or `","` and `": "` when indenting.
+        public var separators: (item: String, key: String)?
+
+        public init(
+            ensureASCII: Bool = true,
+            sortKeys: Bool = false,
+            indent: Int? = nil,
+            separators: (item: String, key: String)? = nil
+        ) {
+            self.ensureASCII = ensureASCII
+            self.sortKeys = sortKeys
+            self.indent = indent
+            self.separators = separators
+        }
+
+        /// Creates options from `json.dumps` keyword arguments,
+        /// as found in an environment's `json.dumps_kwargs` policy.
+        ///
+        /// Recognized keys are `ensure_ascii`, `sort_keys`, `indent`, and `separators`.
+        ///
+        /// - Throws: `JinjaError.runtime` for an unknown key or an unusable value.
+        public init(kwargs: [String: Value]) throws {
+            self.init()
+            for (name, value) in kwargs {
+                switch name {
+                case "ensure_ascii":
+                    ensureASCII = value.isTruthy
+                case "sort_keys":
+                    sortKeys = value.isTruthy
+                case "indent":
+                    switch value {
+                    case .null, .undefined:
+                        indent = nil
+                    case let .int(count):
+                        indent = Swift.max(0, count)
+                    default:
+                        throw JinjaError.runtime("json.dumps indent must be an integer or none")
+                    }
+                case "separators":
+                    switch value {
+                    case .null, .undefined:
+                        separators = nil
+                    case let .array(pair):
+                        guard pair.count == 2,
+                            case let .string(item) = pair[0],
+                            case let .string(key) = pair[1]
+                        else {
+                            throw JinjaError.runtime(
+                                "json.dumps separators must be a pair of strings"
+                            )
+                        }
+                        separators = (item, key)
+                    default:
+                        throw JinjaError.runtime("json.dumps separators must be a pair of strings")
+                    }
+                default:
+                    throw JinjaError.runtime("Unexpected keyword argument '\(name)' for json.dumps")
+                }
+            }
+        }
+    }
+
+    /// Serializes a value the way `json.dumps` does.
+    ///
+    /// - Throws: `JinjaError.runtime` when the value contains something
+    ///   that has no JSON representation, such as a function.
+    public static func dumps(_ value: Value, options: DumpsOptions = DumpsOptions()) throws -> String {
+        var writer = Writer(options: options)
+        try writer.write(value, depth: 0)
+        return writer.output
+    }
+
+    /// Serializes a value the way Jinja2's `tojson` filter does:
+    /// ``dumps(_:options:)`` with `<`, `>`, `&`, and `'` written as `\u` escapes,
+    /// so the result is safe to embed in HTML.
+    public static func htmlSafeDumps(_ value: Value, options: DumpsOptions = DumpsOptions()) throws
+        -> String
+    {
+        try dumps(value, options: options)
+            .replacingOccurrences(of: "<", with: "\\u003c")
+            .replacingOccurrences(of: ">", with: "\\u003e")
+            .replacingOccurrences(of: "&", with: "\\u0026")
+            .replacingOccurrences(of: "'", with: "\\u0027")
+    }
+
+    /// A `json.dumps_function` policy value that gives `tojson` Jinja2's HTML-safe output.
+    ///
+    /// ```swift
+    /// let environment = Environment()
+    /// environment.policies["json.dumps_function"] = JSON.htmlSafeDumpsFunction
+    /// environment.policies["json.dumps_kwargs"] = ["sort_keys": true]
+    /// ```
+    public static let htmlSafeDumpsFunction: Value = .function { args, kwargs, _ in
+        guard let value = args.first else { return .string("null") }
+        return .string(try htmlSafeDumps(value, options: try DumpsOptions(kwargs: kwargs)))
+    }
+}
+
+// MARK: -
+
+extension JSON {
+    private struct Writer {
+        let options: DumpsOptions
+        let itemSeparator: String
+        let keySeparator: String
+        var output = ""
+
+        init(options: DumpsOptions) {
+            self.options = options
+            if let separators = options.separators {
+                itemSeparator = separators.item
+                keySeparator = separators.key
+            } else {
+                itemSeparator = options.indent == nil ? ", " : ","
+                keySeparator = ": "
+            }
+        }
+
+        mutating func write(_ value: Value, depth: Int) throws {
+            switch value {
+            case .null, .undefined:
+                output += "null"
+            case let .boolean(flag):
+                output += flag ? "true" : "false"
+            case let .int(number):
+                output += String(number)
+            case let .double(number):
+                output += pythonRepr(number)
+            case let .string(string):
+                writeString(string)
+            case let .array(items):
+                guard !items.isEmpty else {
+                    output += "[]"
+                    return
+                }
+                output += "["
+                for (index, item) in items.enumerated() {
+                    if index > 0 { output += itemSeparator }
+                    newline(depth: depth + 1)
+                    try write(item, depth: depth + 1)
+                }
+                newline(depth: depth)
+                output += "]"
+            case let .object(members):
+                guard !members.isEmpty else {
+                    output += "{}"
+                    return
+                }
+                var entries = members.map { (key: $0.key.stringValue, value: $0.value) }
+                if options.sortKeys {
+                    entries.sort { $0.key < $1.key }
+                }
+                output += "{"
+                for (index, entry) in entries.enumerated() {
+                    if index > 0 { output += itemSeparator }
+                    newline(depth: depth + 1)
+                    writeString(entry.key)
+                    output += keySeparator
+                    try write(entry.value, depth: depth + 1)
+                }
+                newline(depth: depth)
+                output += "}"
+            case .function:
+                throw JinjaError.runtime("Object of type function is not JSON serializable")
+            case .macro:
+                throw JinjaError.runtime("Object of type macro is not JSON serializable")
+            }
+        }
+
+        private mutating func newline(depth: Int) {
+            guard let indent = options.indent else { return }
+            output += "\n"
+            output += String(repeating: " ", count: indent * depth)
+        }
+
+        private mutating func writeString(_ string: String) {
+            output += "\""
+            for scalar in string.unicodeScalars {
+                switch scalar {
+                case "\"": output += "\\\""
+                case "\\": output += "\\\\"
+                case "\n": output += "\\n"
+                case "\r": output += "\\r"
+                case "\t": output += "\\t"
+                case "\u{08}": output += "\\b"
+                case "\u{0C}": output += "\\f"
+                default:
+                    let isControl = scalar.value < 0x20
+                    let isNonASCII = scalar.value > 0x7E
+                    if isControl || (options.ensureASCII && isNonASCII) {
+                        for unit in String(scalar).utf16 {
+                            output += String(format: "\\u%04x", unit)
+                        }
+                    } else {
+                        output.unicodeScalars.append(scalar)
+                    }
+                }
+            }
+            output += "\""
+        }
+    }
+
+    /// Formats a double the way Python's `float.__repr__` does:
+    /// the shortest digits that round-trip,
+    /// positional for exponents from -4 up to 15,
+    /// and exponential with a signed two-digit exponent otherwise.
+    private static func pythonRepr(_ number: Double) -> String {
+        if number.isNaN { return "NaN" }
+        if number.isInfinite { return number < 0 ? "-Infinity" : "Infinity" }
+        if number == 0 { return number.sign == .minus ? "-0.0" : "0.0" }
+
+        // Swift's description already gives the shortest round-trip digits;
+        // pull them apart and lay them out again by Python's rules.
+        let description = String(number.magnitude)
+        let parts = description.split(separator: "e", maxSplits: 1)
+        let mantissa = parts[0]
+        let exponent = parts.count > 1 ? Int(parts[1]) ?? 0 : 0
+
+        let pointIndex = mantissa.firstIndex(of: ".") ?? mantissa.endIndex
+        let integerLength = mantissa.distance(from: mantissa.startIndex, to: pointIndex)
+        let digits = Array(mantissa.filter { $0 != "." })
+        let firstSignificant = digits.firstIndex { $0 != "0" } ?? 0
+        var significant = Array(digits[firstSignificant...])
+        while significant.count > 1, significant.last == "0" { significant.removeLast() }
+        let decimalExponent = integerLength - 1 - firstSignificant + exponent
+
+        var result = number < 0 ? "-" : ""
+        if decimalExponent >= -4 && decimalExponent < 16 {
+            if decimalExponent >= 0 {
+                let integerCount = decimalExponent + 1
+                let padded =
+                    significant
+                    + Array(repeating: Character("0"), count: Swift.max(0, integerCount - significant.count))
+                result += String(padded[..<integerCount])
+                let fraction = padded[integerCount...]
+                result += "." + (fraction.isEmpty ? "0" : String(fraction))
+            } else {
+                result += "0." + String(repeating: "0", count: -decimalExponent - 1) + String(significant)
+            }
+        } else {
+            result += String(significant[0])
+            if significant.count > 1 {
+                result += "." + String(significant[1...])
+            }
+            result += "e" + (decimalExponent < 0 ? "-" : "+")
+            result += String(format: "%02d", Swift.abs(decimalExponent))
+        }
+        return result
+    }
+}

--- a/Sources/Jinja/JSON.swift
+++ b/Sources/Jinja/JSON.swift
@@ -18,6 +18,7 @@ public enum JSON {
 
         /// Number of spaces to indent nested values by.
         /// `nil` writes everything on one line.
+        /// Zero or negative values insert newlines without leading spaces.
         public var indent: Int?
 
         /// The separators written between items and between a key and its value.
@@ -36,50 +37,26 @@ public enum JSON {
             self.indent = indent
             self.separators = separators
         }
+    }
 
-        /// Creates options from `json.dumps` keyword arguments,
-        /// as found in an environment's `json.dumps_kwargs` policy.
-        ///
-        /// Recognized keys are `ensure_ascii`, `sort_keys`, `indent`, and `separators`.
-        ///
-        /// - Throws: `JinjaError.runtime` for an unknown key or an unusable value.
-        public init(kwargs: [String: Value]) throws {
-            self.init()
-            for (name, value) in kwargs {
-                switch name {
-                case "ensure_ascii":
-                    ensureASCII = value.isTruthy
-                case "sort_keys":
-                    sortKeys = value.isTruthy
-                case "indent":
-                    switch value {
-                    case .null, .undefined:
-                        indent = nil
-                    case let .int(count):
-                        indent = Swift.max(0, count)
-                    default:
-                        throw JinjaError.runtime("json.dumps indent must be an integer or none")
-                    }
-                case "separators":
-                    switch value {
-                    case .null, .undefined:
-                        separators = nil
-                    case let .array(pair):
-                        guard pair.count == 2,
-                            case let .string(item) = pair[0],
-                            case let .string(key) = pair[1]
-                        else {
-                            throw JinjaError.runtime(
-                                "json.dumps separators must be a pair of strings"
-                            )
-                        }
-                        separators = (item, key)
-                    default:
-                        throw JinjaError.runtime("json.dumps separators must be a pair of strings")
-                    }
-                default:
-                    throw JinjaError.runtime("Unexpected keyword argument '\(name)' for json.dumps")
-                }
+    /// The serializer used by the `tojson` filter.
+    public enum Serializer: Sendable {
+        /// Python's `json.dumps` formatting without HTML escaping.
+        case standard
+        /// JSON with `<`, `>`, `&`, and `'` escaped for embedding in HTML.
+        case htmlSafe
+        /// A custom serializer receiving the value and resolved options.
+        case custom(@Sendable (Value, DumpsOptions) throws -> String)
+
+        /// Serializes a value using the selected behavior.
+        public func dumps(_ value: Value, options: DumpsOptions = DumpsOptions()) throws -> String {
+            switch self {
+            case .standard:
+                return try JSON.dumps(value, options: options)
+            case .htmlSafe:
+                return try JSON.htmlSafeDumps(value, options: options)
+            case .custom(let serialize):
+                return try serialize(value, options)
             }
         }
     }
@@ -105,18 +82,6 @@ public enum JSON {
             .replacingOccurrences(of: ">", with: "\\u003e")
             .replacingOccurrences(of: "&", with: "\\u0026")
             .replacingOccurrences(of: "'", with: "\\u0027")
-    }
-
-    /// A `json.dumps_function` policy value that gives `tojson` Jinja2's HTML-safe output.
-    ///
-    /// ```swift
-    /// let environment = Environment()
-    /// environment.policies["json.dumps_function"] = JSON.htmlSafeDumpsFunction
-    /// environment.policies["json.dumps_kwargs"] = ["sort_keys": true]
-    /// ```
-    public static let htmlSafeDumpsFunction: Value = .function { args, kwargs, _ in
-        guard let value = args.first else { return .string("null") }
-        return .string(try htmlSafeDumps(value, options: try DumpsOptions(kwargs: kwargs)))
     }
 }
 
@@ -170,15 +135,24 @@ extension JSON {
                     output += "{}"
                     return
                 }
-                var entries = members.map { (key: $0.key.stringValue, value: $0.value) }
+                var entries = Array(members)
                 if options.sortKeys {
-                    entries.sort { $0.key < $1.key }
+                    try entries.sort {
+                        switch ($0.key, $1.key) {
+                        case let (.int(lhs), .int(rhs)):
+                            return lhs < rhs
+                        case let (.string(lhs), .string(rhs)):
+                            return lhs.unicodeScalars.lexicographicallyPrecedes(rhs.unicodeScalars)
+                        default:
+                            throw JinjaError.runtime("json.dumps cannot sort mixed integer and string keys")
+                        }
+                    }
                 }
                 output += "{"
                 for (index, entry) in entries.enumerated() {
                     if index > 0 { output += itemSeparator }
                     newline(depth: depth + 1)
-                    writeString(entry.key)
+                    writeString(entry.key.stringValue)
                     output += keySeparator
                     try write(entry.value, depth: depth + 1)
                 }
@@ -194,7 +168,7 @@ extension JSON {
         private mutating func newline(depth: Int) {
             guard let indent = options.indent else { return }
             output += "\n"
-            output += String(repeating: " ", count: indent * depth)
+            output += String(repeating: " ", count: Swift.max(0, indent) * depth)
         }
 
         private mutating func writeString(_ string: String) {

--- a/Tests/JinjaTests/FiltersTests.swift
+++ b/Tests/JinjaTests/FiltersTests.swift
@@ -606,7 +606,7 @@ struct FiltersTests {
     @Test("tojson filter honors json.dumps_kwargs policy")
     func tojsonFilterHonorsDumpsKwargsPolicy() throws {
         let env = Environment()
-        env.policies["json.dumps_kwargs"] = ["sort_keys": true]
+        env.policies.jsonDumpsOptions = .init(sortKeys: true)
         let value: Value = ["z": "—", "a": 1]
         let result = try Filters.tojson([value], kwargs: [:], env: env)
         // Jinja2's default policy: sorted keys, and json.dumps' own
@@ -617,7 +617,7 @@ struct FiltersTests {
     @Test("tojson filter arguments override json.dumps_kwargs policy")
     func tojsonFilterArgumentsOverridePolicy() throws {
         let env = Environment()
-        env.policies["json.dumps_kwargs"] = ["sort_keys": true, "indent": 4, "ensure_ascii": true]
+        env.policies.jsonDumpsOptions = .init(ensureASCII: true, sortKeys: true, indent: 4)
         let value: Value = ["b": "—", "a": 1]
         let result = try Filters.tojson(
             [value],
@@ -630,18 +630,24 @@ struct FiltersTests {
     @Test("tojson filter honors json.dumps_function policy")
     func tojsonFilterHonorsDumpsFunctionPolicy() throws {
         let env = Environment()
-        env.policies["json.dumps_function"] = .function { args, kwargs, _ in
-            let indent = kwargs["indent"] ?? .null
-            return .string("dumped \(args.count) value(s) with indent \(indent)")
+        env.policies.jsonDumpsOptions.sortKeys = true
+        env.policies.jsonSerializer = .custom { value, options in
+            #expect(value == .int(1))
+            #expect(options.sortKeys)
+            #expect(!options.ensureASCII)
+            #expect(options.indent == 2)
+            return "custom JSON"
         }
-        let result = try Filters.tojson([.int(1)], kwargs: ["indent": 2], env: env)
-        #expect(result == .string("dumped 1 value(s) with indent 2"))
+        let template = try Template("{{ value | tojson(indent=2) }}")
+        let result = try template.render(["value": 1], environment: env)
+        #expect(result == "custom JSON")
+        #expect(env.policies.jsonDumpsOptions.indent == nil)
     }
 
     @Test("tojson filter can be made HTML-safe like Jinja2")
     func tojsonFilterHTMLSafePolicy() throws {
         let env = Environment()
-        env.policies["json.dumps_function"] = JSON.htmlSafeDumpsFunction
+        env.policies.jsonSerializer = .htmlSafe
         let result = try Filters.tojson([.string("<script>")], kwargs: [:], env: env)
         #expect(result == .string("\"\\u003cscript\\u003e\""))
     }
@@ -649,20 +655,78 @@ struct FiltersTests {
     @Test("tojson filter reads policies from parent environments")
     func tojsonFilterReadsPoliciesFromParent() throws {
         let parent = Environment()
-        parent.policies["json.dumps_kwargs"] = ["sort_keys": true]
+        parent.policies.jsonDumpsOptions.sortKeys = true
         let child = Environment(parent: parent)
         let value: Value = ["b": 1, "a": 2]
         let result = try Filters.tojson([value], kwargs: [:], env: child)
         #expect(result == .string(#"{"a": 2, "b": 1}"#))
     }
 
-    @Test("tojson filter rejects unknown json.dumps_kwargs")
-    func tojsonFilterRejectsUnknownDumpsKwargs() throws {
-        let env = Environment()
-        env.policies["json.dumps_kwargs"] = ["allow_nan": false]
+    @Test("tojson filter rejects invalid template indentation")
+    func tojsonFilterRejectsInvalidIndent() throws {
         #expect(throws: JinjaError.self) {
-            try Filters.tojson([.int(1)], kwargs: [:], env: env)
+            try Filters.tojson([.int(1)], kwargs: ["indent": "invalid"], env: env)
         }
+    }
+
+    @Test("tojson filter normalizes negative template indentation")
+    func tojsonFilterNegativeIndent() throws {
+        #expect(
+            try Filters.tojson([[1]], kwargs: ["indent": -1], env: env)
+                == .string("[\n1\n]")
+        )
+    }
+
+    @Test("tojson filter propagates custom serializer errors")
+    func tojsonFilterCustomError() throws {
+        let environment = Environment()
+        environment.policies.jsonSerializer = .custom { _, _ in
+            throw JinjaError.runtime("custom serializer failed")
+        }
+        let error = #expect(throws: JinjaError.self) {
+            try Filters.tojson([1], env: environment)
+        }
+        #expect(error?.errorDescription == "Runtime error: custom serializer failed")
+    }
+
+    @Test("JSON policy presets apply when rendering templates")
+    func tojsonPolicyPresets() throws {
+        let environment = Environment()
+        let template = try Template("{{ value | tojson }}")
+        let context: Context = ["value": ["z": "—</script>&'", "a": 1]]
+        let plain = #"{"z": "—</script>&'", "a": 1}"#
+        #expect(try template.render(context, environment: environment) == plain)
+        environment.policies = .jinja2
+        #expect(
+            try template.render(context, environment: environment)
+                == #"{"a": 1, "z": "\u2014\u003c/script\u003e\u0026\u0027"}"#
+        )
+        environment.policies = .transformers
+        #expect(try template.render(context, environment: environment) == plain)
+    }
+
+    @Test("Child JSON policy overrides retain inherited settings and isolate mutations")
+    func tojsonPolicyInheritance() throws {
+        let parent = Environment()
+        let child = Environment(parent: parent)
+        parent.policies = .jinja2
+        let template = try Template("{{ value | tojson }}")
+        let context: Context = ["value": ["z": "—<", "a": 1]]
+        #expect(
+            try template.render(context, environment: child)
+                == #"{"a": 1, "z": "\u2014\u003c"}"#
+        )
+        child.policies.jsonDumpsOptions.ensureASCII = false
+        #expect(parent.policies.jsonDumpsOptions.ensureASCII)
+        parent.policies = .transformers
+        #expect(
+            try template.render(context, environment: child)
+                == #"{"a": 1, "z": "—\u003c"}"#
+        )
+        #expect(
+            try template.render(context, environment: parent)
+                == #"{"z": "—<", "a": 1}"#
+        )
     }
 
     @Test("tojson filter does not escape slashes")
@@ -716,7 +780,7 @@ struct FiltersTests {
 
     @Test("tojson filter keeps non-ASCII by default")
     func tojsonFilterKeepsNonASCIIByDefault() throws {
-        // The default json.dumps_kwargs policy sets ensure_ascii=False,
+        // The default Transformers policy sets ensureASCII to false,
         // as transformers does, so "你好" is written as is.
         let result = try Filters.tojson([.string("你好")], kwargs: [:], env: env)
         #expect(result == .string("\"你好\""))

--- a/Tests/JinjaTests/FiltersTests.swift
+++ b/Tests/JinjaTests/FiltersTests.swift
@@ -588,7 +588,81 @@ struct FiltersTests {
     @Test("tojson filter with array")
     func tojsonFilterWithArray() throws {
         let result = try Filters.tojson([.array([.int(1), .int(2), .int(3)])], kwargs: [:], env: env)
-        #expect(result == .string("[1,2,3]"))
+        #expect(result == .string("[1, 2, 3]"))
+    }
+
+    // MARK: tojson policies
+
+    @Test("tojson filter matches transformers by default")
+    func tojsonFilterMatchesTransformersByDefault() throws {
+        // transformers replaces Jinja2's tojson with
+        // json.dumps(ensure_ascii=False, sort_keys=False):
+        // insertion order, a space after "," and ":", and non-ASCII kept as is.
+        let value: Value = ["path": "</style> a/b — c 🏳️", "z": 1]
+        let result = try Filters.tojson([value], kwargs: [:], env: env)
+        #expect(result == .string(#"{"path": "</style> a/b — c 🏳️", "z": 1}"#))
+    }
+
+    @Test("tojson filter honors json.dumps_kwargs policy")
+    func tojsonFilterHonorsDumpsKwargsPolicy() throws {
+        let env = Environment()
+        env.policies["json.dumps_kwargs"] = ["sort_keys": true]
+        let value: Value = ["z": "—", "a": 1]
+        let result = try Filters.tojson([value], kwargs: [:], env: env)
+        // Jinja2's default policy: sorted keys, and json.dumps' own
+        // ensure_ascii=True default applies.
+        #expect(result == .string("{\"a\": 1, \"z\": \"\\u2014\"}"))
+    }
+
+    @Test("tojson filter arguments override json.dumps_kwargs policy")
+    func tojsonFilterArgumentsOverridePolicy() throws {
+        let env = Environment()
+        env.policies["json.dumps_kwargs"] = ["sort_keys": true, "indent": 4, "ensure_ascii": true]
+        let value: Value = ["b": "—", "a": 1]
+        let result = try Filters.tojson(
+            [value],
+            kwargs: ["indent": 2, "ensure_ascii": false],
+            env: env
+        )
+        #expect(result == .string("{\n  \"a\": 1,\n  \"b\": \"—\"\n}"))
+    }
+
+    @Test("tojson filter honors json.dumps_function policy")
+    func tojsonFilterHonorsDumpsFunctionPolicy() throws {
+        let env = Environment()
+        env.policies["json.dumps_function"] = .function { args, kwargs, _ in
+            let indent = kwargs["indent"] ?? .null
+            return .string("dumped \(args.count) value(s) with indent \(indent)")
+        }
+        let result = try Filters.tojson([.int(1)], kwargs: ["indent": 2], env: env)
+        #expect(result == .string("dumped 1 value(s) with indent 2"))
+    }
+
+    @Test("tojson filter can be made HTML-safe like Jinja2")
+    func tojsonFilterHTMLSafePolicy() throws {
+        let env = Environment()
+        env.policies["json.dumps_function"] = JSON.htmlSafeDumpsFunction
+        let result = try Filters.tojson([.string("<script>")], kwargs: [:], env: env)
+        #expect(result == .string("\"\\u003cscript\\u003e\""))
+    }
+
+    @Test("tojson filter reads policies from parent environments")
+    func tojsonFilterReadsPoliciesFromParent() throws {
+        let parent = Environment()
+        parent.policies["json.dumps_kwargs"] = ["sort_keys": true]
+        let child = Environment(parent: parent)
+        let value: Value = ["b": 1, "a": 2]
+        let result = try Filters.tojson([value], kwargs: [:], env: child)
+        #expect(result == .string(#"{"a": 2, "b": 1}"#))
+    }
+
+    @Test("tojson filter rejects unknown json.dumps_kwargs")
+    func tojsonFilterRejectsUnknownDumpsKwargs() throws {
+        let env = Environment()
+        env.policies["json.dumps_kwargs"] = ["allow_nan": false]
+        #expect(throws: JinjaError.self) {
+            try Filters.tojson([.int(1)], kwargs: [:], env: env)
+        }
     }
 
     @Test("tojson filter does not escape slashes")
@@ -604,11 +678,11 @@ struct FiltersTests {
             kwargs: ["indent": .int(2)],
             env: env
         )
-        #expect(result == .string("{\n  \"path\" : \"a/b\"\n}"))
+        #expect(result == .string("{\n  \"path\": \"a/b\"\n}"))
     }
 
-    @Test("tojson filter sorts object keys deterministically")
-    func tojsonFilterSortsObjectKeysDeterministically() throws {
+    @Test("tojson filter preserves object key order")
+    func tojsonFilterPreservesObjectKeyOrder() throws {
         let tool = Value.object([
             "type": .string("function"),
             "function": .object([
@@ -635,23 +709,17 @@ struct FiltersTests {
         #expect(
             result
                 == .string(
-                    "{\"function\":{\"description\":\"Returns the current temperature in degrees Fahrenheit for the provided USA state\",\"name\":\"state_weather\",\"parameters\":{\"properties\":{\"state\":{\"description\":\"The 2 digit code for the USA state. Example: \\\"CA\\\" for California.\",\"type\":\"string\"}},\"required\":[\"state\"],\"type\":\"object\"}},\"type\":\"function\"}"
+                    "{\"type\": \"function\", \"function\": {\"parameters\": {\"type\": \"object\", \"required\": [\"state\"], \"properties\": {\"state\": {\"type\": \"string\", \"description\": \"The 2 digit code for the USA state. Example: \\\"CA\\\" for California.\"}}}, \"name\": \"state_weather\", \"description\": \"Returns the current temperature in degrees Fahrenheit for the provided USA state\"}}"
                 )
         )
     }
 
-    @Test("tojson filter escapes non-ASCII by default")
-    func tojsonFilterEscapesNonASCIIByDefault() throws {
-        // Chinese characters "你好" should be escaped as \uXXXX by default
+    @Test("tojson filter keeps non-ASCII by default")
+    func tojsonFilterKeepsNonASCIIByDefault() throws {
+        // The default json.dumps_kwargs policy sets ensure_ascii=False,
+        // as transformers does, so "你好" is written as is.
         let result = try Filters.tojson([.string("你好")], kwargs: [:], env: env)
-        if case .string(let str) = result {
-            #expect(str.contains("\\u4f60"))  // 你
-            #expect(str.contains("\\u597d"))  // 好
-            #expect(!str.contains("你"))
-            #expect(!str.contains("好"))
-        } else {
-            Issue.record("Expected string result")
-        }
+        #expect(result == .string("\"你好\""))
     }
 
     @Test("tojson filter with ensure_ascii=true")
@@ -1439,11 +1507,12 @@ struct FiltersTests {
         #expect(result == .string("null"))
     }
 
-    @Test("tojson filter with function falls back to null")
+    @Test("tojson filter rejects a function, like json.dumps")
     func tojsonFilterFunction() throws {
         let fn = Value.function { _, _, _ in .null }
-        let result = try Filters.tojson([fn], kwargs: [:], env: env)
-        #expect(result == .string("null"))
+        #expect(throws: JinjaError.self) {
+            try Filters.tojson([fn], kwargs: [:], env: env)
+        }
     }
 
     @Test("abs filter with no args")

--- a/Tests/JinjaTests/FiltersTests.swift
+++ b/Tests/JinjaTests/FiltersTests.swift
@@ -683,10 +683,12 @@ struct FiltersTests {
         environment.policies.jsonSerializer = .custom { _, _ in
             throw JinjaError.runtime("custom serializer failed")
         }
-        let error = #expect(throws: JinjaError.self) {
-            try Filters.tojson([1], env: environment)
+        do {
+            _ = try Filters.tojson([1], env: environment)
+            Issue.record("Expected custom serializer to throw")
+        } catch JinjaError.runtime(let message) {
+            #expect(message == "custom serializer failed")
         }
-        #expect(error?.errorDescription == "Runtime error: custom serializer failed")
     }
 
     @Test("JSON policy presets apply when rendering templates")

--- a/Tests/JinjaTests/FiltersTests.swift
+++ b/Tests/JinjaTests/FiltersTests.swift
@@ -707,6 +707,26 @@ struct FiltersTests {
         #expect(try template.render(context, environment: environment) == plain)
     }
 
+    @Test("JSON policy presets reject missing template values but serialize null")
+    func tojsonPolicyPresetsRejectUndefined() throws {
+        let policies: [Environment.Policies] = [.transformers, .jinja2]
+        for policy in policies {
+            let environment = Environment()
+            environment.policies = policy
+            for source in [
+                "{{ missing | tojson }}",
+                "{{ [missing] | tojson }}",
+                "{{ {'key': missing} | tojson }}",
+            ] {
+                let template = try Template(source)
+                #expect(throws: JinjaError.self) {
+                    try template.render([:], environment: environment)
+                }
+            }
+            #expect(try Template("{{ none | tojson }}").render([:], environment: environment) == "null")
+        }
+    }
+
     @Test("Child JSON policy overrides retain inherited settings and isolate mutations")
     func tojsonPolicyInheritance() throws {
         let parent = Environment()

--- a/Tests/JinjaTests/JSONTests.swift
+++ b/Tests/JinjaTests/JSONTests.swift
@@ -1,0 +1,145 @@
+import Foundation
+import Testing
+
+@testable import Jinja
+
+@Suite("JSON Tests")
+struct JSONTests {
+    // Expected strings below are what Python's `json.dumps` produces
+    // for the same input and keyword arguments.
+
+    @Test("dumps writes a space after commas and colons")
+    func dumpsDefaultSeparators() throws {
+        let value: Value = ["b": 1, "a": [1, 2.5, true, nil, "x"]]
+        #expect(try JSON.dumps(value) == #"{"b": 1, "a": [1, 2.5, true, null, "x"]}"#)
+    }
+
+    @Test("dumps preserves insertion order")
+    func dumpsPreservesInsertionOrder() throws {
+        let value: Value = ["z": 1, "a": 2, "m": 3]
+        #expect(try JSON.dumps(value) == #"{"z": 1, "a": 2, "m": 3}"#)
+    }
+
+    @Test("dumps sorts keys when asked")
+    func dumpsSortKeys() throws {
+        let value: Value = ["z": 1, "a": ["y": 1, "b": 2], "m": 3]
+        #expect(
+            try JSON.dumps(value, options: .init(sortKeys: true))
+                == #"{"a": {"b": 2, "y": 1}, "m": 3, "z": 1}"#
+        )
+    }
+
+    @Test("dumps escapes non-ASCII by default")
+    func dumpsEnsureASCIIDefault() throws {
+        #expect(try JSON.dumps(.string("— 🏳️")) == "\"\\u2014 \\ud83c\\udff3\\ufe0f\"")
+    }
+
+    @Test("dumps keeps non-ASCII with ensure_ascii false")
+    func dumpsEnsureASCIIFalse() throws {
+        #expect(try JSON.dumps(.string("— 🏳️"), options: .init(ensureASCII: false)) == #""— 🏳️""#)
+    }
+
+    @Test("dumps escapes quotes, backslashes, and control characters but not slashes")
+    func dumpsStringEscapes() throws {
+        let input = Value.string("a\"b\\c/d\n\t\u{01}\u{7F}")
+        #expect(try JSON.dumps(input) == "\"a\\\"b\\\\c/d\\n\\t\\u0001\\u007f\"")
+        // With ensure_ascii off, only quotes, backslashes, and C0 controls are escaped.
+        #expect(
+            try JSON.dumps(input, options: .init(ensureASCII: false))
+                == "\"a\\\"b\\\\c/d\\n\\t\\u0001\u{7F}\""
+        )
+    }
+
+    @Test("dumps indents like json.dumps")
+    func dumpsIndent() throws {
+        let value: Value = ["a": [1, 2], "b": [:], "c": []]
+        #expect(
+            try JSON.dumps(value, options: .init(indent: 2))
+                == """
+                {
+                  "a": [
+                    1,
+                    2
+                  ],
+                  "b": {},
+                  "c": []
+                }
+                """
+        )
+    }
+
+    @Test("dumps honors custom separators")
+    func dumpsSeparators() throws {
+        let value: Value = ["a": [1, 2]]
+        #expect(
+            try JSON.dumps(value, options: .init(separators: (",", ":")))
+                == #"{"a":[1,2]}"#
+        )
+    }
+
+    @Test("dumps formats numbers like Python")
+    func dumpsNumbers() throws {
+        #expect(try JSON.dumps(.double(1.0)) == "1.0")
+        #expect(try JSON.dumps(.double(0.1)) == "0.1")
+        #expect(try JSON.dumps(.double(-2.5)) == "-2.5")
+        #expect(try JSON.dumps(.double(1e15)) == "1000000000000000.0")
+        #expect(try JSON.dumps(.double(1e16)) == "1e+16")
+        #expect(try JSON.dumps(.double(0.0001)) == "0.0001")
+        #expect(try JSON.dumps(.double(0.00001)) == "1e-05")
+        #expect(try JSON.dumps(.double(123456.789)) == "123456.789")
+        #expect(try JSON.dumps(.double(0.000123)) == "0.000123")
+        #expect(try JSON.dumps(.double(1.5e-7)) == "1.5e-07")
+        #expect(try JSON.dumps(.double(1e22)) == "1e+22")
+        #expect(try JSON.dumps(.double(12_345_678_901_234_567_890.0)) == "1.2345678901234567e+19")
+        #expect(try JSON.dumps(.int(-42)) == "-42")
+        #expect(try JSON.dumps(.double(.nan)) == "NaN")
+        #expect(try JSON.dumps(.double(.infinity)) == "Infinity")
+        #expect(try JSON.dumps(.double(-.infinity)) == "-Infinity")
+    }
+
+    @Test("dumps writes integer keys as strings")
+    func dumpsIntegerKeys() throws {
+        let value = Value.object([.int(1): .string("one"), .string("two"): .int(2)])
+        #expect(try JSON.dumps(value) == #"{"1": "one", "two": 2}"#)
+    }
+
+    @Test("dumps rejects values that are not JSON serializable")
+    func dumpsRejectsFunctions() throws {
+        let value = Value.function { _, _, _ in .null }
+        #expect(throws: JinjaError.self) {
+            try JSON.dumps(value)
+        }
+    }
+
+    @Test("dumps options can be read from a kwargs object")
+    func dumpsOptionsFromKwargs() throws {
+        let options = try JSON.DumpsOptions(
+            kwargs: [
+                "ensure_ascii": false,
+                "sort_keys": true,
+                "indent": 4,
+                "separators": [",", ": "],
+            ]
+        )
+        #expect(options.ensureASCII == false)
+        #expect(options.sortKeys == true)
+        #expect(options.indent == 4)
+        #expect(options.separators?.item == ",")
+        #expect(options.separators?.key == ": ")
+    }
+
+    @Test("dumps options reject unknown kwargs")
+    func dumpsOptionsRejectUnknownKwargs() throws {
+        #expect(throws: JinjaError.self) {
+            try JSON.DumpsOptions(kwargs: ["allow_nan": false])
+        }
+    }
+
+    @Test("htmlSafeDumps escapes HTML-significant characters like Jinja2")
+    func htmlSafeDumps() throws {
+        #expect(
+            try JSON.htmlSafeDumps(.string("<script>&'\"</script>"))
+                == "\"\\u003cscript\\u003e\\u0026\\u0027\\\"\\u003c/script\\u003e\""
+        )
+    }
+}

--- a/Tests/JinjaTests/JSONTests.swift
+++ b/Tests/JinjaTests/JSONTests.swift
@@ -111,6 +111,17 @@ struct JSONTests {
         }
     }
 
+    @Test("dumps rejects undefined values at any depth")
+    func dumpsRejectsUndefined() throws {
+        let values: [Value] = [.undefined, [.undefined], ["key": .undefined], ["key": [1, .undefined]]]
+        for value in values {
+            #expect(throws: JinjaError.self) {
+                try JSON.dumps(value)
+            }
+        }
+        #expect(try JSON.dumps(.null) == "null")
+    }
+
     @Test("dumps sorts integer keys numerically before stringifying them")
     func dumpsSortsIntegerKeys() throws {
         let value = Value.object([.int(10): .string("ten"), .int(2): .string("two")])

--- a/Tests/JinjaTests/JSONTests.swift
+++ b/Tests/JinjaTests/JSONTests.swift
@@ -111,28 +111,42 @@ struct JSONTests {
         }
     }
 
-    @Test("dumps options can be read from a kwargs object")
-    func dumpsOptionsFromKwargs() throws {
-        let options = try JSON.DumpsOptions(
-            kwargs: [
-                "ensure_ascii": false,
-                "sort_keys": true,
-                "indent": 4,
-                "separators": [",", ": "],
-            ]
+    @Test("dumps sorts integer keys numerically before stringifying them")
+    func dumpsSortsIntegerKeys() throws {
+        let value = Value.object([.int(10): .string("ten"), .int(2): .string("two")])
+        #expect(
+            try JSON.dumps(value, options: .init(sortKeys: true))
+                == #"{"2": "two", "10": "ten"}"#
         )
-        #expect(options.ensureASCII == false)
-        #expect(options.sortKeys == true)
-        #expect(options.indent == 4)
-        #expect(options.separators?.item == ",")
-        #expect(options.separators?.key == ": ")
     }
 
-    @Test("dumps options reject unknown kwargs")
-    func dumpsOptionsRejectUnknownKwargs() throws {
+    @Test("dumps rejects mixed key types only when sorting")
+    func dumpsMixedKeys() throws {
+        let value = Value.object([.int(2): .string("two"), .string("a"): .int(1)])
+        #expect(try JSON.dumps(value) == #"{"2": "two", "a": 1}"#)
         #expect(throws: JinjaError.self) {
-            try JSON.DumpsOptions(kwargs: ["allow_nan": false])
+            try JSON.dumps(value, options: .init(sortKeys: true))
         }
+    }
+
+    @Test("dumps sorts string keys by Unicode scalar order like Python")
+    func dumpsSortsUnicodeKeys() throws {
+        let value: Value = ["é": 1, "z": 2, "e\u{301}x": 3]
+        #expect(
+            try JSON.dumps(value, options: .init(ensureASCII: false, sortKeys: true))
+                == "{\"e\u{301}x\": 3, \"z\": 2, \"é\": 1}"
+        )
+    }
+
+    @Test("dumps treats negative indentation as zero through all option paths")
+    func dumpsNegativeIndent() throws {
+        let value: Value = [[1]]
+        let expected = "[\n[\n1\n]\n]"
+        #expect(try JSON.dumps(value, options: .init(indent: -1)) == expected)
+        var options = JSON.DumpsOptions(indent: 2)
+        options.indent = Int.min
+        #expect(try JSON.dumps(value, options: options) == expected)
+        #expect(try JSON.dumps(value, options: .init(indent: 0)) == expected)
     }
 
     @Test("htmlSafeDumps escapes HTML-significant characters like Jinja2")

--- a/Tests/JinjaTests/TemplateTests.swift
+++ b/Tests/JinjaTests/TemplateTests.swift
@@ -1438,12 +1438,12 @@ struct TemplateTests {
 
         // Check result of template
         let rendered = try Template(string).render(context)
-        #expect(rendered.contains("\"key\":\"value\""))
+        #expect(rendered.contains("\"key\": \"value\""))
         #expect(rendered.contains("\"test\""))
         #expect(rendered.contains("1"))
         #expect(rendered.contains("true"))
         #expect(rendered.contains("null"))
-        #expect(rendered.contains("[1,2,3]"))
+        #expect(rendered.contains("[1, 2, 3]"))
     }
 
     @Test("Filter statements")
@@ -1913,8 +1913,8 @@ struct TemplateTests {
 
         // Check result of template
         let rendered = try Template(string).render(context)
-        #expect(rendered.contains(#""string" : "world""#))
-        #expect(rendered.contains(#""number" : 5"#))
+        #expect(rendered.contains(#""string": "world""#))
+        #expect(rendered.contains(#""number": 5"#))
     }
 
     @Test("Filter operator with map")


### PR DESCRIPTION
Closes #71.

`tojson` now produces what Python's `json.dumps` produces, so a chat template renders the same text here as it does in transformers. Compared with the Foundation encoder it replaces:

| | before | now |
|---|---|---|
| separators | `{"a":1,"b":[1,2]}` | `{"a": 1, "b": [1, 2]}` |
| key order | sorted | insertion order |
| non-ASCII | `\u2014` | `—` |
| floats | `1e+16` / `100` | `1e+16` / `100.0` (Python `repr`) |
| functions / undefined values | `null` | error, as `json.dumps` raises |

The defaults are transformers' (`ensure_ascii=False`, `sort_keys=False`), since that's what the templates this package renders are tested against.

`Environment.policies` is now a typed `Environment.Policies` value. Its `jsonSerializer` is a `JSON.Serializer` enum with `.standard`, `.htmlSafe`, and `.custom` cases; custom serializers accept `(Value, JSON.DumpsOptions)` and return a `String`. The `jsonDumpsOptions` property provides typed `ensureASCII`, `sortKeys`, `indent`, and `separators` settings. Policies are inherited until overridden, preserved during rendering, and the filter's non-null `indent` / `ensure_ascii` arguments take precedence for each call.

The default preset is `.transformers`. To select Jinja2's sorted, ASCII, HTML-safe output:

```swift
let environment = Environment()
environment.policies = .jinja2
```

This makes the HTML-safe behavior discussed in #72 an explicit option. All 833 tests and CI checks pass on Swift 6.0, 6.1, and 6.2.
